### PR TITLE
Add equals?/2 function to types for Ecto 3.5.0 support

### DIFF
--- a/lib/cloak_ecto/type.ex
+++ b/lib/cloak_ecto/type.ex
@@ -23,6 +23,11 @@ defmodule Cloak.Ecto.Type do
       end
 
       @doc false
+      def equal?(term1, term2) do
+        term1 == term2
+      end
+
+      @doc false
       def dump(nil) do
         {:ok, nil}
       end


### PR DESCRIPTION
Attempting to upgrade our application to Ecto 3.5.0 (from 3.4.5) we hit a snag in which some Cloak based types would stop working properly when used in changesets with the following exception:

```
function App.Encrypted.Binary.equal?/2 is undefined or private
```

Where that is defined as:

```elixir
defmodule App.Encrypted.Binary do
  @moduledoc """
  Encrypted Ecto Binary field type for use with Cloak.
  """

  use Cloak.Ecto.Binary, vault: App.Vault
end
```

```elixir
defmodule App.Model do
  import Ecto.Query
  use Ecto.Schema
  import Ecto.Changeset

  schema "models" do
    # ...
    field(:api_key, Encrypted.Binary)
    # ...
  end

  def create_changeset(schema, params \\ %{}) do
    schema
    |> cast(params, [ # Cast would crash app
      # ...
      :api_key,
      # ...
    ])
    # ...
  end

  # ...
end
```

I'm no expert on the internals of Ecto and how Cloak hooks into them, so if this is not right or needs to be different for specific types I'm open to feedback.

For reference, the issue was encountered using Cloak 1.0.2, Cloak_Ecto 1.0.2.