### PR TITLE
Replace the deprecated `:crypto.hmac/3` function

### DIFF
--- a/lib/cloak_ecto/types/hmac.ex
+++ b/lib/cloak_ecto/types/hmac.ex
@@ -1,6 +1,6 @@
 defmodule Cloak.Ecto.HMAC do
   @moduledoc """
-  A custom `Ecto.Type` for hashing fields using `:crypto.hmac/3`.
+  A custom `Ecto.Type` for hashing fields using `:crypto.mac/4`.
 
   ## Why
 
@@ -142,7 +142,7 @@ defmodule Cloak.Ecto.HMAC do
 
       def dump(value) when is_binary(value) do
         config = build_config()
-        {:ok, :crypto.hmac(config[:algorithm], config[:secret], value)}
+        {:ok, :crypto.mac(:hmac, config[:algorithm], config[:secret], value)}
       end
 
       def dump(_value) do

--- a/test/cloak_ecto/types/hmac_test.exs
+++ b/test/cloak_ecto/types/hmac_test.exs
@@ -46,7 +46,7 @@ defmodule Cloak.Ecto.HMACTest do
 
     test "hashes binaries" do
       assert {:ok, hash} = HMAC.dump("plaintext")
-      assert hash == :crypto.hmac(:sha512, "secret", "plaintext")
+      assert hash == :crypto.mac(:hmac, :sha512, "secret", "plaintext")
     end
 
     test "returns :error for all other types" do


### PR DESCRIPTION
with `:crypto.mac/4`. This will bump the minimum project requirement to
OTP 22.1 but will also make it compile under OTP 24.0.