### PR TITLE
Remove pbkdf2 optional dependency, update instructions

### DIFF
--- a/lib/cloak_ecto/types/pbkdf2.ex
+++ b/lib/cloak_ecto/types/pbkdf2.ex
@@ -24,6 +24,12 @@ if Code.ensure_loaded?(:pbkdf2) do
 
         {:pbkdf2, "~> 2.0"}
 
+    If you are using Erlang >= 24, you will need to use a forked version,
+    because `pbkdf2` version `2.0.0` uses `:crypto.hmac` functions that were
+    removed in Erlang 24.
+
+        {:pbkdf2, "~> 2.0", github: "miniclip/erlang-pbkdf2"}
+
     ## Configuration
 
     Create a `PBKDF2` field in your project:

--- a/mix.exs
+++ b/mix.exs
@@ -37,9 +37,12 @@ defmodule Cloak.Ecto.MixProject do
     [
       {:cloak, "~> 1.1.1"},
       {:ecto, "~> 3.0"},
-      # Must use a forked version of pbkdf2 to support Erlang 24
+      # Must use a forked version of pbkdf2 to support Erlang 24. Because Hex only
+      # allows hex packages to be dependencies, this dep cannot be listed as an
+      # optional dependency anymore.
+      #
       # See https://github.com/basho/erlang-pbkdf2/pull/12
-      {:pbkdf2, "~> 2.0", optional: true, github: "miniclip/erlang-pbkdf2"},
+      {:pbkdf2, "~> 2.0", github: "miniclip/erlang-pbkdf2", only: [:dev, :test]},
       {:ex_doc, ">= 0.0.0", only: :dev},
       {:excoveralls, ">= 0.0.0", only: :test},
       {:ecto_sql, ">= 0.0.0", only: [:dev, :test]},


### PR DESCRIPTION
It isn't possible to publish a package to Hex.pm with a dependency on a Github fork which is not also hosted on Hex.pm. The current version of `pbkdf2` is not compatible with Erlang 24. To use it, you'll need a forked version, see #24.

For this reason, I needed to make the `pbkdf2` a `:dev, :test` dependency instead of an `:optional` dependency for `cloak_ecto`. If you add it to your mix dependencies in your project, `cloak_ecto` should still detect it; it shouldn't need to be listed as an optional dependency.

I updated the instructions in the module doc for `Cloak.Ecto.PBKDF2` to reflect this information.