### PR TITLE
Add note about default encrypted values and Ecto validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,11 +26,14 @@ defmodule MyApp.EctoSchema do
 
   schema "table_name" do
     field :encrypted_field, MyApp.Encrypted.Binary
+    field :default_encrypted_field, MyApp.Encrypted.Binary, default: "foo", skip_default_validation: true
 
     # ...
   end
 end
 ```
+
+Note that when setting a default value for a field you need to include the `:skip_default_validation` option. Ecto (`3.6` and greater) will attempt to validate the default value at compile time. Since `cloak` relies on an ETS which is not started at compile time this validation will fail without the option.
 
 When Ecto writes the fields to the database, Cloak encrypts the values into a
 binary blob, using a configured encryption algorithm chosen by you.


### PR DESCRIPTION
Adds a note about using `:skip_default_validation`.

I'm not sure what you want to do here since this project specifies `ecto ~> 3.0` and locks `3.5.6`. Anyone who is on `>= 3.6` will have compilation errors if they are using `:default` on `:field` until they either 1) remove the default or 2) upgrade to `3.7.2`  and pass the `:skip_default_validation` option.