### PR TITLE
Document that `:ciphers` is order-dependent

### DIFF
--- a/guides/how_to/rotate_keys.md
+++ b/guides/how_to/rotate_keys.md
@@ -15,14 +15,20 @@ For example, if your config currently looks like this:
         default: {Cloak.Ciphers.AES.GCM, tag: "AES.GCM.V1", key: <<...>>},
       ]
 
-Then change the `:default` label to the new key, and demote the existing
-key to the `:retired` label.
+Then you should change the `:default` label to the new key, and demote the
+existing key to the `:retired` label.
 
     config :my_app, MyApp.Vault,
       ciphers: [
         default: {Cloak.Ciphers.AES.GCM, tag: "AES.GCM.V2", key: <<...>>},
         retired: {Cloak.Ciphers.AES.GCM, tag: "AES.GCM.V1", key: <<...>>}
       ]
+
+> #### Labels don't matter, order does {: .tip}
+>
+> The `:ciphers` configuration is _order-dependent_. The first key in the list
+> will be used as the default, regardless of its label. This guide uses the 
+> `:default` and `:retired` labels for clarity, but the order is what matters.
 
 ## Migrate Data To New Key
 


### PR DESCRIPTION
Added a tip to the doc on rotating keys:

![Screenshot 2022-06-17 at 10-33-46 Rotate Keys — cloak_ecto v1 2 0](https://user-images.githubusercontent.com/1186992/174349725-2ba40509-746a-456b-ac5a-54f5eb1de9b3.png)

Fixes #33