### PR TITLE
:heavy_minus_sign: Remove dependency on PBKDF2

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -42,7 +42,7 @@ defmodule Cloak.Ecto.MixProject do
       # optional dependency anymore.
       #
       # See https://github.com/basho/erlang-pbkdf2/pull/12
-      {:pbkdf2, "~> 2.0", github: "miniclip/erlang-pbkdf2", only: [:dev, :test]},
+      # {:pbkdf2, "~> 2.0", github: "miniclip/erlang-pbkdf2", only: [:dev, :test]},
       {:ex_doc, ">= 0.0.0", only: :dev},
       {:excoveralls, ">= 0.0.0", only: :test},
       {:ecto_sql, ">= 0.0.0", only: [:dev, :test]},


### PR DESCRIPTION
This is a breaking change. OTP versions > 24.2 now include the `pbkdf2_hmac/5` function in the `:crypto` module, thanks to this PR: https://github.com/erlang/otp/pull/5421

The new function does not include support for all the algorithms that the old dependency supported, namely `md4`, `md5` and `ripemd`. However, I think this is a valid tradeoff.

It is no longer necessary to add a `:pbkdf2` dependency in order to use the PBKDF2 field type.