### PR TITLE
🔒 Use 600,000 iterations in PBKDF2 SHA256

### DIFF
--- a/lib/cloak_ecto/types/pbkdf2.ex
+++ b/lib/cloak_ecto/types/pbkdf2.ex
@@ -44,7 +44,7 @@ if Code.ensure_loaded?(:pbkdf2) do
 
         config :my_app, MyApp.Hashed.PBKDF2,
           algorithm: :sha256,
-          iterations: 10_000,
+          iterations: 600_000,
           secret: "secret",
           size: 64
 
@@ -57,7 +57,7 @@ if Code.ensure_loaded?(:pbkdf2) do
           def init(config) do
             config = Keyword.merge(config, [
               algorithm: :sha256,
-              iterations: 10_000,
+              iterations: 600_000,
               secret: System.get_env("PBKDF2_SECRET")
             ])
 
@@ -135,7 +135,7 @@ if Code.ensure_loaded?(:pbkdf2) do
 
         @impl Cloak.Ecto.PBKDF2
         def init(config) do
-          defaults = [algorithm: :sha256, iterations: 10_000, size: 32]
+          defaults = [algorithm: :sha256, iterations: 600_000, size: 32]
 
           {:ok, defaults |> Keyword.merge(config)}
         end


### PR DESCRIPTION
Also updates the documentation to reflect this, per OWASP recommendations:
https://cheatsheetseries.owasp.org/cheatsheets/Password_Storage_Cheat_Sheet.html#pbkdf2

This iteration count can still be overridden by defining a custom `init/1` function in your app's PBKDF2 module.

h/t to @jc00ke: https://github.com/danielberkompas/cloak_ecto/pull/42#discussion_r1204811194
