### PR TITLE
🐛 Fix `Migrator` when schema contains `Ecto.Enum`

### DIFF
--- a/lib/cloak_ecto/migrator.ex
+++ b/lib/cloak_ecto/migrator.ex
@@ -73,6 +73,10 @@ defmodule Cloak.Ecto.Migrator do
     false
   end
 
+  defp cloak_field?({_field, {:parameterized, Ecto.Enum, _opts}}) do
+    false
+  end
+
   defp cloak_field?({field, {kind, inner_type}}) when kind in [:array, :map] do
     cloak_field?({field, inner_type})
   end

--- a/test/support/migrations/20180321184642_create_users.exs
+++ b/test/support/migrations/20180321184642_create_users.exs
@@ -6,6 +6,7 @@ defmodule Cloak.Ecto.TestRepo.Migrations.CreateUsers do
       add(:name, :string)
       add(:email, :binary)
       add(:email_hash, :binary)
+      add(:status, :string)
 
       timestamps(type: :utc_datetime)
     end

--- a/test/support/user.ex
+++ b/test/support/user.ex
@@ -5,6 +5,8 @@ defmodule Cloak.Ecto.TestUser do
     field(:name, :string)
     field(:email, Cloak.Ecto.Encrypted.Binary)
     field(:email_hash, Cloak.Ecto.Hashed.HMAC)
+    field(:status, Ecto.Enum, values: [active: "active", disabled: "disabled"])
+
     timestamps(type: :utc_datetime)
   end
 end


### PR DESCRIPTION
Fixes #46.

The migrator raised the error in #46 because it didn't expect the `Ecto.Enum` field type when checking which fields contain Cloak types.
