### PR TITLE
Check nil values in SHA256.equal/2

### DIFF
--- a/lib/cloak_ecto/types/sha_256.ex
+++ b/lib/cloak_ecto/types/sha_256.ex
@@ -77,6 +77,10 @@ defmodule Cloak.Ecto.SHA256 do
 
   @doc false
   @impl Ecto.Type
+  def equal?(nil, nil), do: true
+  def equal?(nil, _value), do: false
+  def equal?(_value, nil), do: false
+
   def equal?(value1, value2) do
     hash_string(value1) == hash_string(value2)
   end

--- a/test/cloak_ecto/types/sha256_test.exs
+++ b/test/cloak_ecto/types/sha256_test.exs
@@ -32,6 +32,7 @@ defmodule Cloak.Ecto.SHA256Test do
 
   describe ".equal?/2" do
     test "return true on same values and hashed values" do
+      assert Field.equal?(nil, nil)
       assert Field.equal?("value", "value")
       assert Field.equal?(:crypto.hash(:sha256, "value"), :crypto.hash(:sha256, "value"))
       assert Field.equal?("value", :crypto.hash(:sha256, "value"))
@@ -41,6 +42,8 @@ defmodule Cloak.Ecto.SHA256Test do
     test "return false on different values" do
       refute Field.equal?("value", "not equal")
       refute Field.equal?(:crypto.hash(:sha256, "value"), :crypto.hash(:sha256, "not equal"))
+      refute Field.equal?(nil, "not equal")
+      refute Field.equal?("not equal", nil)
     end
   end
 end


### PR DESCRIPTION
This PR should resolve https://github.com/danielberkompas/cloak_ecto/issues/53

It Checks for nil values in `equal?/2` to avoid call `String.valid/1` with nil

