### PR TITLE
fix: Ecto.Enum type wrapped in tuple

### DIFF
--- a/lib/cloak_ecto/migrator.ex
+++ b/lib/cloak_ecto/migrator.ex
@@ -77,6 +77,10 @@ defmodule Cloak.Ecto.Migrator do
     false
   end
 
+  defp cloak_field?({_field, {:parameterized, {Ecto.Enum, _opts}}}) do
+    false
+  end
+
   defp cloak_field?({field, {kind, inner_type}}) when kind in [:array, :map] do
     cloak_field?({field, inner_type})
   end

--- a/lib/cloak_ecto/migrator.ex
+++ b/lib/cloak_ecto/migrator.ex
@@ -77,6 +77,10 @@ defmodule Cloak.Ecto.Migrator do
     false
   end
 
+  defp cloak_field?({_field, {:parameterized, {Ecto.Embedded, %Ecto.Embedded{}}}}) do
+    false
+  end
+
   defp cloak_field?({_field, {:parameterized, {Ecto.Enum, _opts}}}) do
     false
   end


### PR DESCRIPTION
This fixes a bug with the Ecto.Enum, which seems to be wrapped in tuples.

```elixir
[error] [] Task #PID<0.2169.0> started from Logflare.Vault terminating
** (FunctionClauseError) no function clause matching in Code.ensure_loaded?/1
    (elixir 1.16.0) lib/code.ex:1814: Code.ensure_loaded?({:parameterized, {Ecto.Enum, %{on_load: %{"bigquery" => :bigquery, "datadog" => :datadog, "elastic" => :elastic, "postgres" => :postgres, "webhook" => :webhook}, type: :string, embed_as: :self, on_cast: %{"bigquery" => :bigquery, "datadog" => :datadog, "elastic" => :elastic, "postgres" => :postgres, "webhook" => :webhook}, mappings: [webhook: "webhook", postgres: "postgres", bigquery: "bigquery", datadog: "datadog", elastic: "elastic"], on_dump: %{webhook: "webhook", postgres: "postgres", bigquery: "bigquery", datadog: "datadog", elastic: "elastic"}}}})
    (cloak_ecto 1.3.0) lib/cloak_ecto/migrator.ex:85: Cloak.Ecto.Migrator.cloak_field?/1
    (elixir 1.16.0) lib/enum.ex:4277: Enum.filter_list/2
    (cloak_ecto 1.3.0) lib/cloak_ecto/migrator.ex:62: Cloak.Ecto.Migrator.cloak_fields/1
    (cloak_ecto 1.3.0) lib/cloak_ecto/migrator.ex:21: Cloak.Ecto.Migrator.migrate_schema_with_data/2
    (elixir 1.16.0) lib/enum.ex:1700: Enum."-map/2-lists^map/1-1-"/2
    (logflare 1.8.4) lib/logflare/vault.ex:66: anonymous fn/3 in Logflare.Vault.init/1
    (elixir 1.16.0) lib/task/supervised.ex:101: Task.Supervised.invoke_mfa/2
Function: #Function<2.133720658/0 in Logflare.Vault.init/1>
    Args: []
```