### PR TITLE
add `:default_vault` configuration

### DIFF
--- a/lib/cloak_ecto/migrator/cursor_stream.ex
+++ b/lib/cloak_ecto/migrator/cursor_stream.ex
@@ -77,7 +77,7 @@ defmodule Cloak.Ecto.Migrator.CursorStream do
 
   defp fields_for_cursor(schema, primary_key) do
     if function_exported?(schema, :__cloak_cursor_fields__, 0) do
-      schema.__cloak_cursor_fields__
+      schema.__cloak_cursor_fields__()
     else
       [primary_key]
     end

--- a/lib/cloak_ecto/type.ex
+++ b/lib/cloak_ecto/type.ex
@@ -4,7 +4,7 @@ defmodule Cloak.Ecto.Type do
   @callback __cloak__ :: Keyword.t()
 
   defmacro __using__(opts) do
-    vault = Keyword.fetch!(opts, :vault)
+    vault = Cloak.Ecto.Type.__get_vault__(opts)
     label = opts[:label]
     closure = !!opts[:closure]
 
@@ -119,5 +119,13 @@ defmodule Cloak.Ecto.Type do
         unquote(vault).decrypt(ciphertext)
       end
     end
+  end
+
+  @default_vault Application.compile_env(:cloak, :default_vault)
+
+  @doc false
+  def __get_vault__(opts) do
+    Keyword.get(opts, :vault) || @default_vault ||
+      raise ArgumentError, "No `:vault` option was provided, and no default vault was configured"
   end
 end

--- a/lib/cloak_ecto/types/binary.ex
+++ b/lib/cloak_ecto/types/binary.ex
@@ -25,7 +25,8 @@ defmodule Cloak.Ecto.Binary do
 
   @doc false
   defmacro __using__(opts) do
-    opts = Keyword.merge(opts, vault: Keyword.fetch!(opts, :vault))
+    vault = Cloak.Ecto.Type.__get_vault__(opts)
+    opts = Keyword.merge(opts, vault: vault)
 
     quote location: :keep do
       use Cloak.Ecto.Type, unquote(opts)

--- a/lib/cloak_ecto/types/date.ex
+++ b/lib/cloak_ecto/types/date.ex
@@ -24,7 +24,8 @@ defmodule Cloak.Ecto.Date do
   """
 
   defmacro __using__(opts) do
-    opts = Keyword.merge(opts, vault: Keyword.fetch!(opts, :vault))
+    vault = Cloak.Ecto.Type.__get_vault__(opts)
+    opts = Keyword.merge(opts, vault: vault)
 
     quote do
       use Cloak.Ecto.Type, unquote(opts)

--- a/lib/cloak_ecto/types/date_time.ex
+++ b/lib/cloak_ecto/types/date_time.ex
@@ -24,7 +24,8 @@ defmodule Cloak.Ecto.DateTime do
   """
 
   defmacro __using__(opts) do
-    opts = Keyword.merge(opts, vault: Keyword.fetch!(opts, :vault))
+    vault = Cloak.Ecto.Type.__get_vault__(opts)
+    opts = Keyword.merge(opts, vault: vault)
 
     quote do
       use Cloak.Ecto.Type, unquote(opts)

--- a/lib/cloak_ecto/types/decimal.ex
+++ b/lib/cloak_ecto/types/decimal.ex
@@ -28,7 +28,8 @@ defmodule Cloak.Ecto.Decimal do
 
   @doc false
   defmacro __using__(opts) do
-    opts = Keyword.merge(opts, vault: Keyword.fetch!(opts, :vault))
+    vault = Cloak.Ecto.Type.__get_vault__(opts)
+    opts = Keyword.merge(opts, vault: vault)
 
     quote do
       use Cloak.Ecto.Type, unquote(opts)

--- a/lib/cloak_ecto/types/float.ex
+++ b/lib/cloak_ecto/types/float.ex
@@ -25,7 +25,8 @@ defmodule Cloak.Ecto.Float do
   """
   @doc false
   defmacro __using__(opts) do
-    opts = Keyword.merge(opts, vault: Keyword.fetch!(opts, :vault))
+    vault = Cloak.Ecto.Type.__get_vault__(opts)
+    opts = Keyword.merge(opts, vault: vault)
 
     quote do
       use Cloak.Ecto.Type, unquote(opts)

--- a/lib/cloak_ecto/types/integer.ex
+++ b/lib/cloak_ecto/types/integer.ex
@@ -25,7 +25,8 @@ defmodule Cloak.Ecto.Integer do
 
   @doc false
   defmacro __using__(opts) do
-    opts = Keyword.merge(opts, vault: Keyword.fetch!(opts, :vault))
+    vault = Cloak.Ecto.Type.__get_vault__(opts)
+    opts = Keyword.merge(opts, vault: vault)
 
     quote do
       use Cloak.Ecto.Type, unquote(opts)

--- a/lib/cloak_ecto/types/integer_list.ex
+++ b/lib/cloak_ecto/types/integer_list.ex
@@ -32,7 +32,8 @@ defmodule Cloak.Ecto.IntegerList do
 
   @doc false
   defmacro __using__(opts) do
-    opts = Keyword.merge(opts, vault: Keyword.fetch!(opts, :vault))
+    vault = Cloak.Ecto.Type.__get_vault__(opts)
+    opts = Keyword.merge(opts, vault: vault)
 
     quote location: :keep do
       use Cloak.Ecto.Type, unquote(opts)

--- a/lib/cloak_ecto/types/map.ex
+++ b/lib/cloak_ecto/types/map.ex
@@ -45,7 +45,8 @@ defmodule Cloak.Ecto.Map do
   """
 
   defmacro __using__(opts) do
-    opts = Keyword.merge(opts, vault: Keyword.fetch!(opts, :vault))
+    vault = Cloak.Ecto.Type.__get_vault__(opts)
+    opts = Keyword.merge(opts, vault: vault)
 
     quote location: :keep do
       use Cloak.Ecto.Type, unquote(opts)

--- a/lib/cloak_ecto/types/naive_date_time.ex
+++ b/lib/cloak_ecto/types/naive_date_time.ex
@@ -25,7 +25,8 @@ defmodule Cloak.Ecto.NaiveDateTime do
 
   @doc false
   defmacro __using__(opts) do
-    opts = Keyword.merge(opts, vault: Keyword.fetch!(opts, :vault))
+    vault = Cloak.Ecto.Type.__get_vault__(opts)
+    opts = Keyword.merge(opts, vault: vault)
 
     quote location: :keep do
       use Cloak.Ecto.Type, unquote(opts)

--- a/lib/cloak_ecto/types/string_list.ex
+++ b/lib/cloak_ecto/types/string_list.ex
@@ -36,7 +36,8 @@ defmodule Cloak.Ecto.StringList do
 
   @doc false
   defmacro __using__(opts) do
-    opts = Keyword.merge(opts, vault: Keyword.fetch!(opts, :vault))
+    vault = Cloak.Ecto.Type.__get_vault__(opts)
+    opts = Keyword.merge(opts, vault: vault)
 
     quote location: :keep do
       use Cloak.Ecto.Type, unquote(opts)

--- a/lib/cloak_ecto/types/time.ex
+++ b/lib/cloak_ecto/types/time.ex
@@ -25,7 +25,8 @@ defmodule Cloak.Ecto.Time do
 
   @doc false
   defmacro __using__(opts) do
-    opts = Keyword.merge(opts, vault: Keyword.fetch!(opts, :vault))
+    vault = Cloak.Ecto.Type.__get_vault__(opts)
+    opts = Keyword.merge(opts, vault: vault)
 
     quote location: :keep do
       use Cloak.Ecto.Type, unquote(opts)


### PR DESCRIPTION
Hello :wave:

It has been brought to my attention through our tooling that the classic schema when using
`Cloak.Ecto` creates compile-connected dependencies between the schema and the vault.
Indeed, using `field :field, CustomType` creates a compile dependency to `CustomType`,
which, in this library's use case, has in turn a runtime dependency to `MyApp.Vault`,
creating a compile-connected dependency.

I tried to think of some ways to avoid this:
- One of the solution was to use an API similar to `:polymorphic_embed`, and make
  `Cloak.Ecto` require to use its own `field` macro, but I couldn't really figure
  out how to make it work honestly :no_mouth:
-  The second, much simpler solution, is to allow providing a
  `config :cloak_ecto, default_vault: MyApp.Vault` in the configuration, so that
  the `CustomType` module does not have to reference the `MyApp.Vault` module.
  That obviously does not cover the use-case where projects have multiple vaults...

I did a small PoC of the second option. I did not update the documentation, nor the
unit tests, as I'm just asking your opinion on this option.

Thanks in advance!
